### PR TITLE
feat: adding dynamic SDK versions according to root project

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,12 +25,17 @@ def getExtOrIntegerDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties['FeedbackReporter_' + name]).toInteger()
 }
 
+// Simple helper that allows the root project to override versions declared by this library
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-  compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
-  buildToolsVersion getExtOrDefault('buildToolsVersion')
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
+  
   defaultConfig {
-    minSdkVersion 16
-    targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
+    minSdkVersion safeExtGet("minSdkVersion", 17)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 1
     versionName "1.0"
     


### PR DESCRIPTION
When different projects install feedback reporter as a dependency, we need to make sure we are using the root level API in order to avoid crashes.

This PR will accomplish the verification of the API to make sure the builds always go through.